### PR TITLE
Add interactive browser-based family tree builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # familyTree
-UI for family tree
+Single-page web UI for building and visualising a family tree without a database.
+
+## Getting started
+
+1. Open `index.html` in a browser or serve the project with any static file server.
+2. Use the form controls to add family members and set relationships such as parents, children, and multiple spouses.
+3. Click **Save to LocalStorage** to persist the current state locally. The saved graph will be reloaded automatically on your next visit.
+4. Use **Reset to Sample Data** to restore the provided demo family.
+
+The graph is rendered with the open-source [`vis-network`](https://visjs.github.io/vis-network/docs/network/) library.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Family Tree</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis-network@9.1.2/styles/vis-network.min.css" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Family Tree Builder</h1>
+    <p>Visualize family relationships, including multiple spouses, parents, and children.</p>
+  </header>
+
+  <main>
+    <section class="controls">
+      <div class="card">
+        <h2>Add Family Member</h2>
+        <form id="add-member-form">
+          <label>
+            Name
+            <input type="text" id="member-name" required />
+          </label>
+          <label>
+            Gender
+            <select id="member-gender" required>
+              <option value="female">Female</option>
+              <option value="male">Male</option>
+              <option value="nonbinary">Non-binary</option>
+              <option value="unknown">Prefer not to say</option>
+            </select>
+          </label>
+          <button type="submit">Add Member</button>
+        </form>
+      </div>
+
+      <div class="card">
+        <h2>Add Relationship</h2>
+        <form id="add-relationship-form">
+          <label>
+            Relationship Type
+            <select id="relationship-type" required>
+              <option value="parent">Parent → Child</option>
+              <option value="spouse">Spouses</option>
+            </select>
+          </label>
+
+          <label>
+            <span class="label-text">First Person</span>
+            <select id="relationship-from" required></select>
+          </label>
+
+          <label id="relationship-to-wrapper">
+            <span class="label-text">Second Person</span>
+            <select id="relationship-to" required></select>
+          </label>
+
+          <button type="submit">Add Relationship</button>
+        </form>
+      </div>
+
+      <div class="card">
+        <h2>Storage</h2>
+        <div class="storage-actions">
+          <button id="save-data">Save to LocalStorage</button>
+          <button id="load-data">Reload Saved Data</button>
+          <button id="reset-data" class="danger">Reset to Sample Data</button>
+        </div>
+        <p class="storage-hint">
+          Data persists in this browser using <code>localStorage</code>. Clearing your browser data
+          removes it.
+        </p>
+      </div>
+    </section>
+
+    <section class="graph-container">
+      <div id="network"></div>
+    </section>
+  </main>
+
+  <template id="option-template">
+    <option></option>
+  </template>
+
+  <script src="https://cdn.jsdelivr.net/npm/vis-network@9.1.2/standalone/umd/vis-network.min.js"></script>
+  <script src="scripts.js"></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,241 @@
+const STORAGE_KEY = "family-tree-data";
+const clone =
+  typeof structuredClone === "function"
+    ? structuredClone
+    : (value) => JSON.parse(JSON.stringify(value));
+
+const defaultData = {
+  nodes: [
+    { id: 1, label: "John Carter", gender: "male" },
+    { id: 2, label: "Mary Carter", gender: "female" },
+    { id: 3, label: "Linda Carter", gender: "female" },
+    { id: 4, label: "Kevin Carter", gender: "male" },
+    { id: 5, label: "Anna Carter", gender: "female" },
+    { id: 6, label: "Paul Carter", gender: "male" },
+  ],
+  edges: [
+    { id: "1-2", from: 1, to: 2, label: "spouse", type: "spouse" },
+    { id: "1-3", from: 1, to: 3, label: "spouse", type: "spouse" },
+    { id: "1>4", from: 1, to: 4, label: "parent", type: "parent" },
+    { id: "2>4", from: 2, to: 4, label: "parent", type: "parent" },
+    { id: "1>5", from: 1, to: 5, label: "parent", type: "parent" },
+    { id: "2>5", from: 2, to: 5, label: "parent", type: "parent" },
+    { id: "1>6", from: 1, to: 6, label: "parent", type: "parent" },
+    { id: "3>6", from: 3, to: 6, label: "parent", type: "parent" },
+  ],
+};
+
+let network;
+let nodes;
+let edges;
+
+const addMemberForm = document.getElementById("add-member-form");
+const memberNameInput = document.getElementById("member-name");
+const memberGenderSelect = document.getElementById("member-gender");
+const addRelationshipForm = document.getElementById("add-relationship-form");
+const relationshipTypeSelect = document.getElementById("relationship-type");
+const relationshipFromSelect = document.getElementById("relationship-from");
+const relationshipToSelect = document.getElementById("relationship-to");
+const relationshipToLabelText = document.querySelector(
+  "#relationship-to-wrapper .label-text"
+);
+const saveButton = document.getElementById("save-data");
+const loadButton = document.getElementById("load-data");
+const resetButton = document.getElementById("reset-data");
+
+function loadFromStorage() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) {
+      return clone(defaultData);
+    }
+    const parsed = JSON.parse(saved);
+    if (!parsed.nodes || !parsed.edges) {
+      throw new Error("Invalid saved structure");
+    }
+    return parsed;
+  } catch (error) {
+    console.warn("Failed to load data, using defaults", error);
+    return clone(defaultData);
+  }
+}
+
+function persistToStorage() {
+  const data = {
+    nodes: nodes.get(),
+    edges: edges.get(),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+function resetToDefaults() {
+  nodes.clear();
+  edges.clear();
+  nodes.add(defaultData.nodes);
+  edges.add(defaultData.edges.map(formatEdge));
+  persistToStorage();
+  populatePersonSelects();
+}
+
+function formatEdge(edge) {
+  const isSpouse = edge.type === "spouse";
+  return {
+    ...edge,
+    color: isSpouse ? { color: "#ef4444" } : { color: "#10b981" },
+    arrows: isSpouse ? undefined : "to",
+    smooth: isSpouse,
+  };
+}
+
+function buildNetwork() {
+  const container = document.getElementById("network");
+  const options = {
+    layout: { improvedLayout: true, hierarchical: false },
+    physics: {
+      stabilization: true,
+      barnesHut: {
+        gravitationalConstant: -5000,
+        springLength: 140,
+      },
+    },
+    edges: {
+      smooth: {
+        type: "continuous",
+        roundness: 0.4,
+      },
+      font: {
+        size: 12,
+        color: "#4b5563",
+        background: "rgba(255,255,255,0.7)",
+      },
+    },
+    nodes: {
+      shape: "box",
+      borderWidth: 1,
+      borderWidthSelected: 2,
+      margin: 10,
+      font: {
+        size: 14,
+        color: "#111827",
+      },
+    },
+  };
+
+  network = new vis.Network(container, { nodes, edges }, options);
+}
+
+function populatePersonSelects() {
+  const members = nodes.get();
+  [relationshipFromSelect, relationshipToSelect].forEach((select) => {
+    select.innerHTML = "";
+    const fragment = document.createDocumentFragment();
+    members
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .forEach((member) => {
+        const option = document.createElement("option");
+        option.value = member.id;
+        option.textContent = member.label;
+        fragment.appendChild(option);
+      });
+    select.appendChild(fragment);
+  });
+}
+
+function initializeData() {
+  const initialData = loadFromStorage();
+  nodes = new vis.DataSet(initialData.nodes);
+  edges = new vis.DataSet(initialData.edges.map(formatEdge));
+  buildNetwork();
+  populatePersonSelects();
+}
+
+function createMember(event) {
+  event.preventDefault();
+  const name = memberNameInput.value.trim();
+  const gender = memberGenderSelect.value;
+
+  if (!name) {
+    return;
+  }
+
+  const ids = nodes.getIds();
+  const nextId = ids.length ? Math.max(...ids) + 1 : 1;
+  nodes.add({ id: nextId, label: name, gender });
+  populatePersonSelects();
+  memberNameInput.value = "";
+  persistToStorage();
+}
+
+function relationshipExists(from, to, type) {
+  return edges.get({
+    filter: (edge) => {
+      if (edge.type !== type) {
+        return false;
+      }
+      if (type === "spouse") {
+        return (
+          (edge.from === from && edge.to === to) ||
+          (edge.from === to && edge.to === from)
+        );
+      }
+      return edge.from === from && edge.to === to;
+    },
+  }).length > 0;
+}
+
+function createRelationship(event) {
+  event.preventDefault();
+
+  const type = relationshipTypeSelect.value;
+  const from = Number(relationshipFromSelect.value);
+  const to = Number(relationshipToSelect.value);
+
+  if (!from || !to || from === to) {
+    alert("Please choose two different family members.");
+    return;
+  }
+
+  if (relationshipExists(from, to, type)) {
+    alert("This relationship already exists.");
+    return;
+  }
+
+  const idSuffix = type === "spouse" ? `${Math.min(from, to)}-${Math.max(from, to)}` : `${from}>${to}`;
+  edges.add(
+    formatEdge({
+      id: idSuffix,
+      from,
+      to,
+      label: type === "spouse" ? "spouse" : "parent",
+      type,
+    })
+  );
+  persistToStorage();
+}
+
+function bindEvents() {
+  addMemberForm.addEventListener("submit", createMember);
+  addRelationshipForm.addEventListener("submit", createRelationship);
+  saveButton.addEventListener("click", persistToStorage);
+  loadButton.addEventListener("click", () => {
+    const stored = loadFromStorage();
+    nodes.clear();
+    edges.clear();
+    nodes.add(stored.nodes);
+    edges.add(stored.edges.map(formatEdge));
+    populatePersonSelects();
+  });
+  resetButton.addEventListener("click", () => {
+    if (confirm("Reset to sample data? This will overwrite current entries.")) {
+      resetToDefaults();
+    }
+  });
+
+  relationshipTypeSelect.addEventListener("change", () => {
+    const isSpouse = relationshipTypeSelect.value === "spouse";
+    relationshipToLabelText.textContent = isSpouse ? "Second Spouse" : "Child";
+  });
+}
+
+initializeData();
+bindEvents();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f6f7fb;
+  color: #1d1d1f;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  background: linear-gradient(135deg, #4a90e2, #7b61ff);
+  color: white;
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+}
+
+header p {
+  margin: 0;
+  max-width: 600px;
+  font-size: clamp(1rem, 2.5vw, 1.15rem);
+  line-height: 1.5;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.5rem;
+  padding: clamp(1rem, 3vw, 2rem);
+  box-sizing: border-box;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 20px rgba(31, 41, 55, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #3c3c43;
+}
+
+input[type="text"],
+select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d0d3dc;
+  font-size: 1rem;
+  background-color: #fdfdff;
+}
+
+button {
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  background: linear-gradient(135deg, #4a90e2, #7b61ff);
+  color: white;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(76, 110, 245, 0.3);
+}
+
+button.danger {
+  background: linear-gradient(135deg, #ff5f6d, #ffc371);
+}
+
+.storage-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.storage-hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.graph-container {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(31, 41, 55, 0.12);
+  padding: 1rem;
+  display: flex;
+}
+
+#network {
+  width: 100%;
+  height: calc(100vh - 220px);
+  min-height: 400px;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .graph-container {
+    height: 500px;
+  }
+
+  #network {
+    height: 100%;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #111827;
+    color: #f9fafb;
+  }
+
+  header {
+    box-shadow: none;
+  }
+
+  .card,
+  .graph-container {
+    background: #1f2937;
+    box-shadow: none;
+  }
+
+  label {
+    color: #e5e7eb;
+  }
+
+  input[type="text"],
+  select {
+    background-color: #111827;
+    color: inherit;
+    border-color: #374151;
+  }
+
+  #network {
+    border-color: #374151;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static family tree builder that renders relationships with the vis-network open source graph library
- implement localStorage-backed sample data with forms to add members, parent/child and multi-spouse relationships
- add styling and usage documentation for serving and persisting the browser-only experience

## Testing
- [ ] Not run

------
https://chatgpt.com/codex/tasks/task_e_68da44b22d6083239a3931502d81c6c0