### PR TITLE
Revamp family tree dashboard UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,74 +8,129 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header>
-    <h1>Family Tree Builder</h1>
-    <p>Visualize family relationships, including multiple spouses, parents, and children.</p>
+  <header class="top-bar">
+    <div class="brand">
+      <div class="brand-mark">FT</div>
+      <div class="brand-copy">
+        <h1>Family Tree Studio</h1>
+        <p>Design a beautiful, data-rich view of the people you love.</p>
+      </div>
+    </div>
+    <div class="header-actions">
+      <button class="primary">Export</button>
+      <button class="ghost">Help</button>
+    </div>
   </header>
 
-  <main>
-    <section class="controls">
-      <div class="card">
+  <main class="dashboard">
+    <aside class="sidebar">
+      <section class="card">
         <h2>Add Family Member</h2>
-        <form id="add-member-form">
-          <label>
-            Name
-            <input type="text" id="member-name" required />
+        <form id="add-member-form" class="stack">
+          <label class="field">
+            <span>Name</span>
+            <input type="text" id="member-name" placeholder="e.g. Jane Doe" required />
           </label>
-          <label>
-            Gender
+          <label class="field">
+            <span>Gender</span>
             <select id="member-gender" required>
               <option value="female">Female</option>
               <option value="male">Male</option>
-              <option value="nonbinary">Non-binary</option>
-              <option value="unknown">Prefer not to say</option>
             </select>
           </label>
-          <button type="submit">Add Member</button>
+          <button type="submit" class="primary">Add Member</button>
         </form>
-      </div>
+      </section>
 
-      <div class="card">
+      <section class="card">
         <h2>Add Relationship</h2>
-        <form id="add-relationship-form">
-          <label>
-            Relationship Type
+        <form id="add-relationship-form" class="stack">
+          <label class="field">
+            <span>Relationship Type</span>
             <select id="relationship-type" required>
               <option value="parent">Parent → Child</option>
               <option value="spouse">Spouses</option>
             </select>
           </label>
-
-          <label>
+          <label class="field">
             <span class="label-text">First Person</span>
             <select id="relationship-from" required></select>
           </label>
-
-          <label id="relationship-to-wrapper">
+          <label class="field" id="relationship-to-wrapper">
             <span class="label-text">Second Person</span>
             <select id="relationship-to" required></select>
           </label>
-
-          <button type="submit">Add Relationship</button>
+          <button type="submit" class="primary">Add Relationship</button>
         </form>
-      </div>
+      </section>
 
-      <div class="card">
+      <section class="card">
         <h2>Storage</h2>
         <div class="storage-actions">
-          <button id="save-data">Save to LocalStorage</button>
-          <button id="load-data">Reload Saved Data</button>
-          <button id="reset-data" class="danger">Reset to Sample Data</button>
+          <button id="save-data" class="ghost">Save to LocalStorage</button>
+          <button id="load-data" class="ghost">Reload Saved Data</button>
+          <button id="reset-data" class="danger ghost">Reset to Sample Data</button>
         </div>
         <p class="storage-hint">
           Data persists in this browser using <code>localStorage</code>. Clearing your browser data
           removes it.
         </p>
-      </div>
-    </section>
+      </section>
+    </aside>
 
-    <section class="graph-container">
-      <div id="network"></div>
+    <section class="workspace">
+      <nav class="view-tabs" aria-label="Primary views">
+        <button type="button" class="active" data-target="graph">Graph</button>
+        <button type="button" data-target="members">Members</button>
+        <button type="button" data-target="relationships">Relationships</button>
+      </nav>
+
+      <div class="view-panel active" data-view="graph">
+        <div class="panel-header">
+          <h2>Family Graph</h2>
+          <p>Interactive network showing spouses, parents, and children.</p>
+        </div>
+        <div class="graph-container">
+          <div id="network"></div>
+        </div>
+      </div>
+
+      <div class="view-panel" data-view="members">
+        <div class="panel-header">
+          <h2>Members</h2>
+          <p>Directory of everyone in your family tree.</p>
+        </div>
+        <div class="table-wrapper">
+          <table id="members-table">
+            <thead>
+              <tr>
+                <th scope="col">Person</th>
+                <th scope="col">Gender</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="view-panel" data-view="relationships">
+        <div class="panel-header">
+          <h2>Relationships</h2>
+          <p>Explore how each person connects to others.</p>
+        </div>
+        <div class="table-wrapper">
+          <table id="relationships-table">
+            <thead>
+              <tr>
+                <th scope="col">Type</th>
+                <th scope="col">From</th>
+                <th scope="col">To</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/scripts.js
+++ b/scripts.js
@@ -29,6 +29,8 @@ let network;
 let nodes;
 let edges;
 
+const avatarCache = new Map();
+
 const addMemberForm = document.getElementById("add-member-form");
 const memberNameInput = document.getElementById("member-name");
 const memberGenderSelect = document.getElementById("member-gender");
@@ -42,6 +44,12 @@ const relationshipToLabelText = document.querySelector(
 const saveButton = document.getElementById("save-data");
 const loadButton = document.getElementById("load-data");
 const resetButton = document.getElementById("reset-data");
+const membersTableBody = document.querySelector("#members-table tbody");
+const relationshipsTableBody = document.querySelector(
+  "#relationships-table tbody"
+);
+const viewButtons = document.querySelectorAll(".view-tabs button");
+const viewPanels = document.querySelectorAll(".view-panel");
 
 function loadFromStorage() {
   try {
@@ -62,8 +70,10 @@ function loadFromStorage() {
 
 function persistToStorage() {
   const data = {
-    nodes: nodes.get(),
-    edges: edges.get(),
+    nodes: nodes.get().map(({ id, label, gender }) => ({ id, label, gender })),
+    edges: edges
+      .get()
+      .map(({ id, from, to, label, type }) => ({ id, from, to, label, type })),
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -71,53 +81,80 @@ function persistToStorage() {
 function resetToDefaults() {
   nodes.clear();
   edges.clear();
-  nodes.add(defaultData.nodes);
+  nodes.add(defaultData.nodes.map(prepareNode));
   edges.add(defaultData.edges.map(formatEdge));
-  persistToStorage();
   populatePersonSelects();
+  renderMembersTable();
+  renderRelationshipsTable();
+  persistToStorage();
 }
 
 function formatEdge(edge) {
   const isSpouse = edge.type === "spouse";
+  const colors = isSpouse
+    ? { color: "#ef4444", highlight: "#b91c1c" }
+    : { color: "#10b981", highlight: "#047857" };
+
   return {
     ...edge,
-    color: isSpouse ? { color: "#ef4444" } : { color: "#10b981" },
+    color: { color: colors.color, highlight: colors.highlight },
     arrows: isSpouse ? undefined : "to",
-    smooth: isSpouse,
+    dashes: isSpouse,
+    smooth: { enabled: isSpouse, type: "curvedCW", roundness: 0.3 },
+    font: {
+      size: 13,
+      color: "#4b5563",
+      strokeColor: "#ffffff",
+      strokeWidth: 3,
+    },
   };
 }
 
 function buildNetwork() {
   const container = document.getElementById("network");
   const options = {
-    layout: { improvedLayout: true, hierarchical: false },
+    layout: { improvedLayout: true },
     physics: {
       stabilization: true,
       barnesHut: {
-        gravitationalConstant: -5000,
-        springLength: 140,
+        gravitationalConstant: -3500,
+        springLength: 160,
+        springConstant: 0.04,
       },
     },
     edges: {
       smooth: {
         type: "continuous",
-        roundness: 0.4,
+        roundness: 0.3,
       },
-      font: {
-        size: 12,
-        color: "#4b5563",
-        background: "rgba(255,255,255,0.7)",
-      },
+      selectionWidth: 1,
+      hoverWidth: 0,
     },
     nodes: {
-      shape: "box",
-      borderWidth: 1,
-      borderWidthSelected: 2,
-      margin: 10,
-      font: {
-        size: 14,
-        color: "#111827",
+      shape: "circularImage",
+      size: 42,
+      borderWidth: 3,
+      borderWidthSelected: 4,
+      color: {
+        border: "#6366f1",
+        background: "#eef2ff",
+        highlight: {
+          border: "#4338ca",
+          background: "#e0e7ff",
+        },
       },
+      font: {
+        size: 16,
+        color: "#111827",
+        face: '"Inter", "Segoe UI", sans-serif',
+      },
+      imagePadding: { top: 12, bottom: 6 },
+      margin: 12,
+      shadow: true,
+    },
+    interaction: {
+      tooltipDelay: 120,
+      hover: true,
     },
   };
 
@@ -125,28 +162,160 @@ function buildNetwork() {
 }
 
 function populatePersonSelects() {
-  const members = nodes.get();
-  [relationshipFromSelect, relationshipToSelect].forEach((select) => {
+  const members = nodes.get().sort((a, b) => a.label.localeCompare(b.label));
+  const selects = [relationshipFromSelect, relationshipToSelect];
+  selects.forEach((select) => {
+    const previous = select.value;
     select.innerHTML = "";
-    const fragment = document.createDocumentFragment();
-    members
-      .sort((a, b) => a.label.localeCompare(b.label))
-      .forEach((member) => {
-        const option = document.createElement("option");
-        option.value = member.id;
-        option.textContent = member.label;
-        fragment.appendChild(option);
-      });
-    select.appendChild(fragment);
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Select";
+    placeholder.disabled = true;
+    if (!previous) {
+      placeholder.selected = true;
+    }
+    select.appendChild(placeholder);
+
+    members.forEach((member) => {
+      const option = document.createElement("option");
+      option.value = member.id;
+      option.textContent = member.label;
+      select.appendChild(option);
+    });
+
+    if (previous && members.some((member) => String(member.id) === previous)) {
+      select.value = previous;
+    } else {
+      select.selectedIndex = 0;
+    }
   });
+}
+
+function initialsFromName(name) {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) {
+    return "?";
+  }
+  const [first, last] = [parts[0], parts.length > 1 ? parts[parts.length - 1] : ""];
+  const initials = (first[0] || "") + (last[0] || "");
+  return initials.toUpperCase();
+}
+
+function createAvatar(name, gender) {
+  const key = `${gender}:${name}`;
+  if (avatarCache.has(key)) {
+    return avatarCache.get(key);
+  }
+
+  const palette =
+    gender === "female"
+      ? { bg: "#fdf2f8", border: "#f472b6", text: "#db2777" }
+      : { bg: "#dbeafe", border: "#60a5fa", text: "#1d4ed8" };
+  const initials = initialsFromName(name);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+      <defs>
+        <linearGradient id="grad" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0%" stop-color="${palette.bg}" />
+          <stop offset="100%" stop-color="${palette.border}" />
+        </linearGradient>
+      </defs>
+      <rect x="4" y="4" width="88" height="88" rx="28" fill="url(#grad)" stroke="${palette.border}" stroke-width="4" />
+      <text x="50%" y="55%" text-anchor="middle" font-size="36" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" fill="${palette.text}">${initials}</text>
+    </svg>`;
+  const encoded = btoa(unescape(encodeURIComponent(svg)));
+  const dataUri = `data:image/svg+xml;base64,${encoded}`;
+  avatarCache.set(key, dataUri);
+  return dataUri;
+}
+
+function prepareNode(node) {
+  return {
+    ...node,
+    image: createAvatar(node.label, node.gender),
+  };
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (match) => {
+    const map = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    };
+    return map[match] || match;
+  });
+}
+
+function renderMembersTable() {
+  const members = nodes.get().sort((a, b) => a.label.localeCompare(b.label));
+  if (!members.length) {
+    membersTableBody.innerHTML =
+      '<tr><td colspan="2"><div class="empty-state">Add your first member to begin building the tree.</div></td></tr>';
+    return;
+  }
+
+  const rows = members
+    .map((member) => {
+      const safeName = escapeHtml(member.label);
+      const avatar = member.image || createAvatar(member.label, member.gender);
+      return `<tr>
+        <td>
+          <div class="person-cell">
+            <img src="${avatar}" alt="" aria-hidden="true" />
+            <span class="person-name">${safeName}</span>
+          </div>
+        </td>
+        <td><span class="badge ${member.gender}">${escapeHtml(member.gender)}</span></td>
+      </tr>`;
+    })
+    .join("");
+  membersTableBody.innerHTML = rows;
+}
+
+function renderRelationshipsTable() {
+  const relationships = edges.get();
+  if (!relationships.length) {
+    relationshipsTableBody.innerHTML =
+      '<tr><td colspan="3"><div class="empty-state">No relationships yet. Create one to connect your members.</div></td></tr>';
+    return;
+  }
+
+  const rows = relationships
+    .sort((a, b) => {
+      if (a.type !== b.type) {
+        return a.type.localeCompare(b.type);
+      }
+      if (a.from !== b.from) {
+        return a.from - b.from;
+      }
+      return a.to - b.to;
+    })
+    .map((relationship) => {
+      const fromMember = nodes.get(relationship.from);
+      const toMember = nodes.get(relationship.to);
+      const typeLabel = relationship.type === "spouse" ? "Spouses" : "Parent → Child";
+      const fromName = escapeHtml(fromMember?.label ?? "Unknown");
+      const toName = escapeHtml(toMember?.label ?? "Unknown");
+      return `<tr>
+        <td class="relationship-type">${typeLabel}</td>
+        <td>${fromName}</td>
+        <td>${toName}</td>
+      </tr>`;
+    })
+    .join("");
+  relationshipsTableBody.innerHTML = rows;
 }
 
 function initializeData() {
   const initialData = loadFromStorage();
-  nodes = new vis.DataSet(initialData.nodes);
+  nodes = new vis.DataSet(initialData.nodes.map(prepareNode));
   edges = new vis.DataSet(initialData.edges.map(formatEdge));
   buildNetwork();
   populatePersonSelects();
+  renderMembersTable();
+  renderRelationshipsTable();
 }
 
 function createMember(event) {
@@ -160,27 +329,31 @@ function createMember(event) {
 
   const ids = nodes.getIds();
   const nextId = ids.length ? Math.max(...ids) + 1 : 1;
-  nodes.add({ id: nextId, label: name, gender });
+  nodes.add(prepareNode({ id: nextId, label: name, gender }));
   populatePersonSelects();
+  renderMembersTable();
   memberNameInput.value = "";
+  memberNameInput.focus();
   persistToStorage();
 }
 
 function relationshipExists(from, to, type) {
-  return edges.get({
-    filter: (edge) => {
-      if (edge.type !== type) {
-        return false;
-      }
-      if (type === "spouse") {
-        return (
-          (edge.from === from && edge.to === to) ||
-          (edge.from === to && edge.to === from)
-        );
-      }
-      return edge.from === from && edge.to === to;
-    },
-  }).length > 0;
+  return (
+    edges.get({
+      filter: (edge) => {
+        if (edge.type !== type) {
+          return false;
+        }
+        if (type === "spouse") {
+          return (
+            (edge.from === from && edge.to === to) ||
+            (edge.from === to && edge.to === from)
+          );
+        }
+        return edge.from === from && edge.to === to;
+      },
+    }).length > 0
+  );
 }
 
 function createRelationship(event) {
@@ -200,7 +373,8 @@ function createRelationship(event) {
     return;
   }
 
-  const idSuffix = type === "spouse" ? `${Math.min(from, to)}-${Math.max(from, to)}` : `${from}>${to}`;
+  const idSuffix =
+    type === "spouse" ? `${Math.min(from, to)}-${Math.max(from, to)}` : `${from}>${to}`;
   edges.add(
     formatEdge({
       id: idSuffix,
@@ -210,20 +384,26 @@ function createRelationship(event) {
       type,
     })
   );
+  renderRelationshipsTable();
   persistToStorage();
 }
 
 function bindEvents() {
   addMemberForm.addEventListener("submit", createMember);
   addRelationshipForm.addEventListener("submit", createRelationship);
-  saveButton.addEventListener("click", persistToStorage);
+  saveButton.addEventListener("click", () => {
+    persistToStorage();
+    alert("Family tree saved to this browser.");
+  });
   loadButton.addEventListener("click", () => {
     const stored = loadFromStorage();
     nodes.clear();
     edges.clear();
-    nodes.add(stored.nodes);
+    nodes.add(stored.nodes.map(prepareNode));
     edges.add(stored.edges.map(formatEdge));
     populatePersonSelects();
+    renderMembersTable();
+    renderRelationshipsTable();
   });
   resetButton.addEventListener("click", () => {
     if (confirm("Reset to sample data? This will overwrite current entries.")) {
@@ -235,7 +415,32 @@ function bindEvents() {
     const isSpouse = relationshipTypeSelect.value === "spouse";
     relationshipToLabelText.textContent = isSpouse ? "Second Spouse" : "Child";
   });
+
+  viewButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      if (button.classList.contains("active")) {
+        return;
+      }
+      const target = button.dataset.target;
+      viewButtons.forEach((btn) => btn.classList.toggle("active", btn === button));
+      viewPanels.forEach((panel) =>
+        panel.classList.toggle("active", panel.dataset.view === target)
+      );
+      if (target === "graph" && network) {
+        setTimeout(() => {
+          network.redraw();
+          network.fit({
+            animation: {
+              duration: 450,
+              easingFunction: "easeInOutCubic",
+            },
+          });
+        }, 150);
+      }
+    });
+  });
 }
 
 initializeData();
 bindEvents();
+relationshipTypeSelect.dispatchEvent(new Event("change"));

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,21 @@
 :root {
   color-scheme: light dark;
-  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  background-color: #f6f7fb;
-  color: #1d1d1f;
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --bg-surface: #f4f6fb;
+  --surface: #ffffff;
+  --surface-muted: #f0f2f8;
+  --border: #d9deec;
+  --text-primary: #111827;
+  --text-secondary: #6b7280;
+  --primary: #4f46e5;
+  --primary-accent: #6366f1;
+  --danger: #ef4444;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
@@ -10,93 +23,160 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.06), transparent 240px),
+    var(--bg-surface);
 }
 
-header {
-  background: linear-gradient(135deg, #4a90e2, #7b61ff);
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.brand-mark {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: radial-gradient(circle at top left, var(--primary), #8b5cf6);
   color: white;
-  padding: 2rem clamp(1rem, 4vw, 3rem);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  letter-spacing: 0.08em;
 }
 
-header h1 {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.8rem, 4vw, 2.5rem);
-}
-
-header p {
+.brand-copy h1 {
   margin: 0;
-  max-width: 600px;
-  font-size: clamp(1rem, 2.5vw, 1.15rem);
-  line-height: 1.5;
+  font-size: clamp(1.4rem, 3.5vw, 2.1rem);
+  font-weight: 700;
 }
 
-main {
+.brand-copy p {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.dashboard {
   flex: 1;
   display: grid;
-  grid-template-columns: 320px 1fr;
-  gap: 1.5rem;
-  padding: clamp(1rem, 3vw, 2rem);
-  box-sizing: border-box;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: clamp(1.25rem, 4vw, 2.5rem);
+  padding: clamp(1.5rem, 5vw, 3rem);
 }
 
-.controls {
+.sidebar {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
 .card {
-  background: white;
-  border-radius: 12px;
-  padding: 1.25rem;
-  box-shadow: 0 12px 20px rgba(31, 41, 55, 0.12);
+  background: var(--surface);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 30px 50px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.stack {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.card h2 {
-  margin: 0;
-  font-size: 1.25rem;
-}
-
-label {
+.field {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.5rem;
   font-weight: 600;
-  color: #3c3c43;
+  color: var(--text-secondary);
+}
+
+.field span {
+  font-size: 0.95rem;
 }
 
 input[type="text"],
 select {
-  padding: 0.6rem 0.75rem;
-  border-radius: 8px;
-  border: 1px solid #d0d3dc;
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
   font-size: 1rem;
-  background-color: #fdfdff;
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"]:focus,
+select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+  background: #fff;
 }
 
 button {
-  padding: 0.65rem 1rem;
-  border-radius: 999px;
   border: none;
+  border-radius: 999px;
   font-weight: 600;
   font-size: 0.95rem;
+  padding: 0.65rem 1.25rem;
   cursor: pointer;
-  background: linear-gradient(135deg, #4a90e2, #7b61ff);
-  color: white;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
 }
 
-button:hover {
+button.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-accent));
+  color: white;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.25);
+}
+
+button.primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(76, 110, 245, 0.3);
+  box-shadow: 0 18px 30px rgba(79, 70, 229, 0.28);
+}
+
+button.ghost {
+  background: rgba(99, 102, 241, 0.08);
+  color: var(--primary);
+}
+
+button.ghost:hover {
+  background: rgba(99, 102, 241, 0.12);
 }
 
 button.danger {
-  background: linear-gradient(135deg, #ff5f6d, #ffc371);
+  color: var(--danger);
+}
+
+button.danger:hover {
+  background: rgba(239, 68, 68, 0.12);
 }
 
 .storage-actions {
@@ -107,68 +187,212 @@ button.danger {
 
 .storage-hint {
   margin: 0;
-  color: #6b7280;
-  font-size: 0.9rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.workspace {
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.view-tabs {
+  display: inline-flex;
+  align-self: flex-start;
+  background: var(--surface);
+  border-radius: 999px;
+  padding: 0.35rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.12);
+}
+
+.view-tabs button {
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.view-tabs button.active {
+  background: linear-gradient(135deg, var(--primary), var(--primary-accent));
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(79, 70, 229, 0.3);
+}
+
+.view-panel {
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: 0 35px 60px rgba(15, 23, 42, 0.07);
+}
+
+.view-panel.active {
+  display: flex;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.panel-header p {
+  margin: 0.4rem 0 0;
+  color: var(--text-secondary);
 }
 
 .graph-container {
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 40px rgba(31, 41, 55, 0.12);
+  background: linear-gradient(180deg, rgba(79, 70, 229, 0.06), transparent 70%);
+  border-radius: 18px;
   padding: 1rem;
-  display: flex;
+  border: 1px solid rgba(99, 102, 241, 0.18);
 }
 
 #network {
   width: 100%;
-  height: calc(100vh - 220px);
-  min-height: 400px;
-  border-radius: 10px;
-  border: 1px solid #e5e7eb;
+  height: clamp(360px, 60vh, 640px);
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid var(--border);
 }
 
-@media (max-width: 1024px) {
-  main {
+.table-wrapper {
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+}
+
+table thead {
+  background: var(--surface-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+table th,
+table td {
+  text-align: left;
+  padding: 0.9rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.person-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.person-cell img {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 2px solid rgba(99, 102, 241, 0.2);
+  object-fit: cover;
+}
+
+.person-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.badge.female {
+  background: rgba(236, 72, 153, 0.12);
+  color: #db2777;
+}
+
+.badge.male {
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+}
+
+.relationship-type {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 1100px) {
+  .dashboard {
     grid-template-columns: 1fr;
   }
 
-  .graph-container {
-    height: 500px;
+  .sidebar {
+    order: 2;
   }
 
-  #network {
-    height: 100%;
+  .workspace {
+    order: 1;
   }
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    background-color: #111827;
-    color: #f9fafb;
+    --bg-surface: #0f172a;
+    --surface: #111827;
+    --surface-muted: #1f2937;
+    --border: #1f2937;
+    --text-primary: #f9fafb;
+    --text-secondary: #cbd5f5;
   }
 
-  header {
-    box-shadow: none;
+  body {
+    background: linear-gradient(180deg, rgba(99, 102, 241, 0.2), transparent 280px),
+      var(--bg-surface);
   }
 
-  .card,
+  .brand-copy p,
+  .storage-hint,
+  .panel-header p {
+    color: rgba(226, 232, 240, 0.75);
+  }
+
+  button.ghost {
+    background: rgba(99, 102, 241, 0.22);
+    color: #c7d2fe;
+  }
+
+  button.ghost:hover {
+    background: rgba(99, 102, 241, 0.3);
+  }
+
   .graph-container {
-    background: #1f2937;
-    box-shadow: none;
-  }
-
-  label {
-    color: #e5e7eb;
-  }
-
-  input[type="text"],
-  select {
-    background-color: #111827;
-    color: inherit;
-    border-color: #374151;
+    border-color: rgba(99, 102, 241, 0.35);
   }
 
   #network {
-    border-color: #374151;
+    border-color: rgba(99, 102, 241, 0.35);
   }
 }


### PR DESCRIPTION
## Summary
- redesign the dashboard with a SaaS-inspired header, sidebar forms, and tabbed workspace for graph, members, and relationships views while limiting gender options to female or male
- populate new members and relationships tables with generated avatars, badges, and live updates tied to the network data
- refresh the visual styling and network configuration for circular image nodes with gradients and improved spacing across light and dark modes

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da48d93a8c8323a6bed0396e273d7d