### PR TITLE
Fix blank load and enforce marriage rule for parent relationships

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,9 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div id="root"></div>
+  <div id="root">
+    <div class="preload-message">Loading Family Tree Studio…</div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/vis-network@9.1.2/standalone/umd/vis-network.min.js"></script>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,29 @@
 html,
-body,
-#root {
+body {
   margin: 0;
   height: 100%;
   font-family: "Roboto", "Inter", "Segoe UI", sans-serif;
   background-color: #f3f4f6;
 }
 
+#root {
+  min-height: 100vh;
+  height: 100%;
+}
+
 body {
   -webkit-font-smoothing: antialiased;
   color: #0f172a;
+}
+
+.preload-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-size: 1.125rem;
+  color: #4b5563;
+  letter-spacing: 0.02em;
 }
 
 .network-surface {


### PR DESCRIPTION
## Summary
- add a preload message and robust icon fallbacks so the page no longer renders blank if icon assets fail
- extend family relationships with a divorced state and require a spouse or divorce before creating parent-child links
- refresh sample data, styling, and labels to surface the divorced relationship and clarify relationship forms

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da538314e4832395905e73c8c63163