### PR TITLE
Fix family tree graph height overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,8 +28,8 @@ body {
 
 .network-surface {
   width: 100%;
-  height: 100%;
-  min-height: 480px;
+  height: clamp(480px, 60vh, 720px);
+  flex: 1 1 auto;
   background: radial-gradient(circle at top, rgba(99, 102, 241, 0.05), transparent 65%),
     #ffffff;
 }


### PR DESCRIPTION
## Summary
- clamp the network surface height so the vis graph stays within the viewport
- allow the canvas container to flex without forcing an infinite page height

## Testing
- no automated tests were run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da59ca7fb88323b3f60a7cbfa367f4