### PR TITLE
Improve layout responsiveness and add photo support

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@ body {
 
 .network-surface {
   width: 100%;
-  height: clamp(480px, 60vh, 720px);
+  height: clamp(320px, 55vh, 720px);
   flex: 1 1 auto;
   background: radial-gradient(circle at top, rgba(99, 102, 241, 0.05), transparent 65%),
     #ffffff;


### PR DESCRIPTION
## Summary
- allow storing portrait URLs for members and show the photos across the graph, table, and detail panel with graceful fallbacks
- move the navigation tabs into a sticky top app bar, add a footer, and tune layouts for better responsiveness
- stabilize and refit the network when revisiting the graph so the visualization stays centered

## Testing
- No automated tests were run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68da60a614b483238654b5e0c9c5cf71