### PR TITLE
Improve family tree responsiveness and navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,8 @@ body {
 
 .network-surface {
   width: 100%;
-  height: clamp(320px, 55vh, 720px);
+  height: 100%;
+  min-height: clamp(360px, 70vh, 900px);
   flex: 1 1 auto;
   background: radial-gradient(circle at top, rgba(99, 102, 241, 0.05), transparent 65%),
     #ffffff;


### PR DESCRIPTION
## Summary
- add an inline SVG logo, update the header layout, and provide a control to expand the family graph to full width
- ensure the network resizes correctly when returning to the graph tab and only show the member detail drawer after a person is selected
- replace relationship drop-downs with searchable autocompletes so large families remain manageable

## Testing
- Manual UI verification via `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68da661aa68c8323acefdf99708d7d25