### PR TITLE
Fix network graph initialization

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -276,7 +276,6 @@ function useNetwork(
   const simulationRef = React.useRef(null);
   const selectCallbackRef = React.useRef(onSelectMember);
   const selectedIdRef = React.useRef(selectedMemberId ?? null);
-  const containerNode = containerRef.current;
 
   React.useEffect(() => {
     selectCallbackRef.current = onSelectMember;
@@ -361,6 +360,7 @@ function useNetwork(
   }, []);
 
   React.useEffect(() => {
+    const containerNode = containerRef.current;
     const d3 = window.d3;
     if (!containerNode || !d3) {
       return undefined;
@@ -495,7 +495,7 @@ function useNetwork(
         simulationRef.current = null;
       }
     };
-  }, [containerNode, fitNetwork]);
+  }, [fitNetwork]);
 
   React.useEffect(() => {
     const d3 = window.d3;


### PR DESCRIPTION
## Summary
- ensure the D3 network initialization hook reads the container ref after mount so the SVG is created
- remove the dependency on a render-time container ref snapshot that never updated

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dbd7dd99d88323be42718f95dd60f1