### PR TITLE
Fix icon loading fallback when CDN is unavailable

### DIFF
--- a/icons.js
+++ b/icons.js
@@ -4,37 +4,58 @@ const iconsSource =
   window.MaterialUI?.Icons ||
   {};
 
-const fallbackIconFactory = (symbol) => (props = {}) => {
-  const { sx, style, ...rest } = props;
-  const host = MaterialUI?.Icon;
-  if (host) {
-    return React.createElement(host, { ...rest, sx }, symbol);
-  }
-  return React.createElement(
-    "span",
-    {
-      ...rest,
-      style: {
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: 24,
-        height: 24,
-        fontSize: "1.25rem",
-        lineHeight: 1,
-        ...(style || {}),
+const fallbackIconFactory = (symbol) => {
+  const fallback = (props = {}) => {
+    const { sx, style, ...rest } = props;
+    const host = MaterialUI?.Icon;
+    if (host) {
+      return React.createElement(host, { ...rest, sx }, symbol);
+    }
+    return React.createElement(
+      "span",
+      {
+        ...rest,
+        style: {
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 24,
+          height: 24,
+          fontSize: "1.25rem",
+          lineHeight: 1,
+          ...(style || {}),
+        },
       },
-    },
-    symbol
-  );
+      symbol
+    );
+  };
+  return fallback;
 };
 
-export const EditIcon = iconsSource.Edit || fallbackIconFactory("✏️");
-export const DeleteIcon = iconsSource.Delete || fallbackIconFactory("🗑️");
-export const AddIcon = iconsSource.Add || fallbackIconFactory("＋");
-export const CloseIcon = iconsSource.Close || fallbackIconFactory("✖️");
-export const CheckIcon = iconsSource.Check || fallbackIconFactory("✔️");
-export const ExpandIcon = iconsSource.Fullscreen || fallbackIconFactory("⛶");
-export const CollapseIcon =
-  iconsSource.FullscreenExit || fallbackIconFactory("🗗");
-export const SearchIcon = iconsSource.Search || fallbackIconFactory("🔍");
+const createIcon = (sourceName, ligature, fallbackSymbol = ligature) => {
+  if (iconsSource[sourceName]) {
+    return iconsSource[sourceName];
+  }
+  const renderFallbackSymbol = fallbackIconFactory(fallbackSymbol);
+  return (props = {}) => {
+    const host = MaterialUI?.Icon;
+    if (host) {
+      const { sx, style, ...rest } = props;
+      return React.createElement(host, { ...rest, sx, style }, ligature);
+    }
+    return renderFallbackSymbol(props);
+  };
+};
+
+export const EditIcon = createIcon("Edit", "edit", "✏️");
+export const DeleteIcon = createIcon("Delete", "delete", "🗑️");
+export const AddIcon = createIcon("Add", "add", "＋");
+export const CloseIcon = createIcon("Close", "close", "✖️");
+export const CheckIcon = createIcon("Check", "check", "✔️");
+export const ExpandIcon = createIcon("Fullscreen", "fullscreen", "⛶");
+export const CollapseIcon = createIcon(
+  "FullscreenExit",
+  "fullscreen_exit",
+  "🗗"
+);
+export const SearchIcon = createIcon("Search", "search", "🔍");

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@mui/material@5.15.8/umd/material-ui.development.js" crossorigin></script>
-  <script src="https://unpkg.com/@mui/icons-material@5.15.8/umd/material-ui-icons.development.js" crossorigin></script>
   <script src="https://unpkg.com/@emotion/react@11.11.3/dist/emotion-react.umd.min.js" crossorigin></script>
   <script src="https://unpkg.com/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone@7.23.9/babel.min.js"></script>


### PR DESCRIPTION
## Summary
- remove the broken @mui/icons-material CDN script that returned 404s
- update the local icon utilities to render ligature icons through Material UI when available and fall back gracefully otherwise

## Testing
- not run (no test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68dbe12275dc8323bab7a01f78eb9ae3