### PR TITLE
Improve parent relationship direction indicator

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -138,18 +138,18 @@ function useNetwork(
     defs
       .append("marker")
       .attr("id", "arrow-parent")
-      .attr("viewBox", "0 0 16 16")
-      .attr("refX", 13)
-      .attr("refY", 8)
-      .attr("markerWidth", 14)
-      .attr("markerHeight", 14)
+      .attr("viewBox", "0 0 18 18")
+      .attr("refX", 14)
+      .attr("refY", 9)
+      .attr("markerWidth", 18)
+      .attr("markerHeight", 18)
       .attr("orient", "auto")
       .attr("markerUnits", "strokeWidth")
       .append("path")
-      .attr("d", "M2,2 L14,8 L2,14 L5.5,8 Z")
-      .attr("fill", "#047857")
-      .attr("stroke", "#ecfdf5")
-      .attr("stroke-width", 1.2);
+      .attr("d", "M3,2 L16,9 L3,16 L7.5,9 Z")
+      .attr("fill", "#10b981")
+      .attr("stroke", "#065f46")
+      .attr("stroke-width", 1.5);
 
     const zoomGroup = svg.append("g").attr("class", "network-zoom");
     const linkGroup = zoomGroup.append("g").attr("class", "network-links");

--- a/data.js
+++ b/data.js
@@ -311,11 +311,7 @@
       ...edge,
       color,
       highlight,
-      labelText: isSpouse
-        ? "Spouse"
-        : isDivorced
-        ? "Divorced"
-        : "Parent ➜ Child",
+      labelText: isSpouse ? "Spouse" : isDivorced ? "Divorced" : null,
       dashArray: isSpouse ? "6,6" : isDivorced ? "4,8" : null,
       distance: isSpouse ? 200 : isDivorced ? 220 : 150,
       strength: isSpouse || isDivorced ? 0.5 : 0.9,


### PR DESCRIPTION
## Summary
- enlarge and recolor the parent relationship marker so edges show a clearer arrow toward the child
- hide the parent relationship label text so the arrow conveys the direction without extra labeling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc3486439083239d81d9dcd40cb7c0