### PR TITLE
Add date of birth field to member profiles

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -545,6 +545,7 @@ function App() {
   const [memberGender, setMemberGender] = React.useState("female");
   const [memberLifeStatus, setMemberLifeStatus] = React.useState("Alive");
   const [memberAddress, setMemberAddress] = React.useState("");
+  const [memberDateOfBirth, setMemberDateOfBirth] = React.useState("");
   const [memberImageUrl, setMemberImageUrl] = React.useState("");
   const [memberAttributes, setMemberAttributes] = React.useState([]);
   const [memberNameError, setMemberNameError] = React.useState("");
@@ -742,6 +743,7 @@ function App() {
     setMemberGender("female");
     setMemberLifeStatus("Alive");
     setMemberAddress("");
+    setMemberDateOfBirth("");
     setMemberImageUrl("");
     setMemberAttributes([]);
     setMemberNameError("");
@@ -771,6 +773,7 @@ function App() {
       gender: member.gender,
       lifeStatus: member.attributes?.lifeStatus || "Alive",
       address: member.attributes?.address || "",
+      dateOfBirth: member.attributes?.dateOfBirth || "",
       imageUrl: member.imageUrl || "",
       customAttributes: attributesToCustomList(member.attributes),
     });
@@ -852,7 +855,8 @@ function App() {
       attributes: compileAttributes(
         editingMemberDraft.lifeStatus,
         editingMemberDraft.customAttributes,
-        editingMemberDraft.address
+        editingMemberDraft.address,
+        editingMemberDraft.dateOfBirth
       ),
     };
     setMembers((prev) =>
@@ -880,7 +884,8 @@ function App() {
       attributes: compileAttributes(
         memberLifeStatus,
         memberAttributes,
-        memberAddress
+        memberAddress,
+        memberDateOfBirth
       ),
     };
     setMembers((prev) => [...prev, newMember]);
@@ -1058,6 +1063,7 @@ function App() {
           gender: memberGender,
           lifeStatus: memberLifeStatus,
           address: memberAddress,
+          dateOfBirth: memberDateOfBirth,
           imageUrl: memberImageUrl,
           attributes: memberAttributes,
           nameError: memberNameError,
@@ -1065,6 +1071,7 @@ function App() {
           onGenderChange: setMemberGender,
           onLifeStatusChange: setMemberLifeStatus,
           onAddressChange: setMemberAddress,
+          onDateOfBirthChange: setMemberDateOfBirth,
           onImageUrlChange: setMemberImageUrl,
           onAddAttribute: handleAddAttribute,
           onAttributeChange: handleMemberAttributeChange,

--- a/components/AppLayout.jsx
+++ b/components/AppLayout.jsx
@@ -75,6 +75,7 @@
     gender: memberGender,
     lifeStatus: memberLifeStatus,
     address: memberAddress,
+    dateOfBirth: memberDateOfBirth,
     imageUrl: memberImageUrl,
     attributes: memberAttributes,
     nameError: memberNameError,
@@ -82,6 +83,7 @@
     onGenderChange: onMemberGenderChange,
     onLifeStatusChange: onMemberLifeStatusChange,
     onAddressChange: onMemberAddressChange,
+    onDateOfBirthChange: onMemberDateOfBirthChange,
     onImageUrlChange: onMemberImageUrlChange,
     onAddAttribute: onAddMemberAttribute,
     onAttributeChange: onMemberAttributeChange,
@@ -206,8 +208,20 @@
         />
       );
     }
+    if (member.attributes?.dateOfBirth) {
+      chips.push(
+        <Chip
+          key="dateOfBirth"
+          label={`Born: ${member.attributes.dateOfBirth}`}
+          size="small"
+          variant="outlined"
+        />
+      );
+    }
     Object.entries(member.attributes || {})
-      .filter(([key]) => key !== "lifeStatus" && key !== "address")
+      .filter(
+        ([key]) => key !== "lifeStatus" && key !== "address" && key !== "dateOfBirth"
+      )
       .forEach(([key, value]) => {
         chips.push(
           <Chip key={key} label={`${key}: ${value}`} size="small" variant="outlined" />
@@ -358,6 +372,16 @@
                           value={memberAddress}
                           onChange={(event) => onMemberAddressChange(event.target.value)}
                           placeholder="e.g. 123 Main St, Springfield"
+                          fullWidth
+                        />
+                        <TextField
+                          label="Date of Birth"
+                          type="date"
+                          value={memberDateOfBirth}
+                          onChange={(event) =>
+                            onMemberDateOfBirthChange(event.target.value)
+                          }
+                          InputLabelProps={{ shrink: true }}
                           fullWidth
                         />
                         <TextField
@@ -778,11 +802,22 @@
                             avatarSource && avatarSource.length > 0
                               ? avatarSource
                               : fallbackAvatar;
-                          const secondaryLine =
-                            member.attributes?.address ||
-                            member.attributes?.occupation ||
-                            member.attributes?.hometown ||
-                            "";
+                          const secondaryLineParts = [];
+                          if (member.attributes?.dateOfBirth) {
+                            secondaryLineParts.push(
+                              `Born ${member.attributes.dateOfBirth}`
+                            );
+                          }
+                          if (member.attributes?.address) {
+                            secondaryLineParts.push(member.attributes.address);
+                          }
+                          if (member.attributes?.occupation) {
+                            secondaryLineParts.push(member.attributes.occupation);
+                          }
+                          if (member.attributes?.hometown) {
+                            secondaryLineParts.push(member.attributes.hometown);
+                          }
+                          const secondaryLine = secondaryLineParts.join(" • ");
                           return (
                             <TableRow key={member.id} hover selected={isEditing}>
                               <TableCell sx={{ minWidth: 220 }}>
@@ -895,6 +930,24 @@
                                       }
                                       size="small"
                                       fullWidth
+                                    />
+                                    <TextField
+                                      label="Date of Birth"
+                                      type="date"
+                                      value={
+                                        draft?.dateOfBirth ??
+                                        member.attributes?.dateOfBirth ??
+                                        ""
+                                      }
+                                      onChange={(event) =>
+                                        onEditingFieldChange(
+                                          "dateOfBirth",
+                                          event.target.value
+                                        )
+                                      }
+                                      size="small"
+                                      fullWidth
+                                      InputLabelProps={{ shrink: true }}
                                     />
                                     <TextField
                                       label="Photo URL"

--- a/components/MemberDetailPanel.jsx
+++ b/components/MemberDetailPanel.jsx
@@ -22,9 +22,11 @@
       ? getMemberAvatarAssets(member)
       : emptyAvatarAssets;
     const address = member?.attributes?.address || "";
+    const dateOfBirth = member?.attributes?.dateOfBirth || "";
     const otherAttributes = hasSelection
       ? Object.entries(member.attributes || {}).filter(
-          ([key]) => key !== "lifeStatus" && key !== "address"
+          ([key]) =>
+            key !== "lifeStatus" && key !== "address" && key !== "dateOfBirth"
         )
       : [];
     const mapUrl = address
@@ -125,6 +127,16 @@
                   </Stack>
                 </Box>
               </Stack>
+              {dateOfBirth && (
+                <Box>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Date of Birth
+                  </Typography>
+                  <Typography variant="body2" sx={{ mt: 0.5 }}>
+                    {dateOfBirth}
+                  </Typography>
+                </Box>
+              )}
               {address && (
                 <Box>
                   <Typography variant="subtitle2" color="text.secondary">

--- a/data.js
+++ b/data.js
@@ -17,6 +17,7 @@
           lifeStatus: "Alive",
           occupation: "Engineer",
           address: "1200 Pine St, Seattle, WA",
+          dateOfBirth: "1970-08-12",
         },
       },
       {
@@ -25,7 +26,11 @@
         gender: "female",
         imageUrl:
           "https://as2.ftcdn.net/v2/jpg/14/16/03/35/1000_F_1416033509_ud5Bt37B3E58hEyA10qfpmP5nWg82ozR.jpg",
-        attributes: { lifeStatus: "Deceased", address: "45 Maple Ave, Eugene, OR" },
+        attributes: {
+          lifeStatus: "Deceased",
+          address: "45 Maple Ave, Eugene, OR",
+          dateOfBirth: "1972-03-04",
+        },
       },
       {
         id: 3,
@@ -37,6 +42,7 @@
           lifeStatus: "Alive",
           hometown: "Portland",
           address: "300 Riverwalk Dr, Portland, OR",
+          dateOfBirth: "1980-11-22",
         },
       },
       {
@@ -45,7 +51,11 @@
         gender: "male",
         imageUrl:
           "https://as1.ftcdn.net/v2/jpg/15/13/67/74/1000_F_1513677460_9ZE0mmpsntQgSTfQwWPpkMa2ToXf94SO.jpg",
-        attributes: { lifeStatus: "Alive", address: "102 Garden Ln, Spokane, WA" },
+        attributes: {
+          lifeStatus: "Alive",
+          address: "102 Garden Ln, Spokane, WA",
+          dateOfBirth: "1995-06-18",
+        },
       },
       {
         id: 5,
@@ -57,6 +67,7 @@
           lifeStatus: "Alive",
           hobby: "Painting",
           address: "780 Sunset Blvd, Boise, ID",
+          dateOfBirth: "1998-02-09",
         },
       },
       {
@@ -65,7 +76,11 @@
         gender: "male",
         imageUrl:
           "https://as2.ftcdn.net/v2/jpg/15/07/83/75/1000_F_1507837582_4PfjhXazq5b6L57hvgrTKh37EScUKrND.webp",
-        attributes: { lifeStatus: "Alive", address: "18 Orchard Rd, Salem, OR" },
+        attributes: {
+          lifeStatus: "Alive",
+          address: "18 Orchard Rd, Salem, OR",
+          dateOfBirth: "2010-05-03",
+        },
       },
     ],
     relationships: [
@@ -324,7 +339,8 @@
 
   function attributesToCustomList(attributes) {
     const entries = Object.entries(attributes || {}).filter(
-      ([key]) => key !== "lifeStatus" && key !== "address"
+      ([key]) =>
+        key !== "lifeStatus" && key !== "address" && key !== "dateOfBirth"
     );
     if (!entries.length) {
       return [];
@@ -332,11 +348,20 @@
     return entries.map(([key, value]) => ({ id: createAttributeId(), key, value }));
   }
 
-  function compileAttributes(lifeStatus, customAttributes, address = "") {
+  function compileAttributes(
+    lifeStatus,
+    customAttributes,
+    address = "",
+    dateOfBirth = ""
+  ) {
     const attributes = { lifeStatus };
     const trimmedAddress = address.trim();
     if (trimmedAddress) {
       attributes.address = trimmedAddress;
+    }
+    const trimmedDateOfBirth = dateOfBirth.trim();
+    if (trimmedDateOfBirth) {
+      attributes.dateOfBirth = trimmedDateOfBirth;
     }
     customAttributes.forEach((attr) => {
       const key = attr.key.trim();


### PR DESCRIPTION
## Summary
- add a dedicated date of birth attribute to the seeded member data and storage helpers
- extend member creation and editing forms to capture dates of birth alongside addresses and other attributes
- surface dates of birth in the directory table, detail panel, and attribute chips for quick reference

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dcded81da0832389d69ab9ff18005d