### PR TITLE
Fix missing React globals for browser build

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1,3 +1,5 @@
+const React = window.React;
+const ReactDOM = window.ReactDOM;
 const { AppLayout } = window.FamilyTreeComponents;
 const { HashRouter, useLocation, useNavigate } = window.ReactRouterDOM;
 


### PR DESCRIPTION
## Summary
- expose the React and ReactDOM globals inside app.jsx so Babel-transpiled JSX can access them

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd0fc0a3ac8323b3a74255fbc7ed4c