### PR TITLE
Replace React Router with custom hash navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
   <script src="https://unpkg.com/@mui/material@5.15.8/umd/material-ui.development.js" crossorigin></script>
   <script src="https://unpkg.com/@emotion/react@11.11.3/dist/emotion-react.umd.min.js" crossorigin></script>
   <script src="https://unpkg.com/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone@7.23.9/babel.min.js"></script>
   <script src="icons.js"></script>
   <script type="text/babel" data-presets="env" src="data.js"></script>


### PR DESCRIPTION
## Summary
- replace the React Router dependency with an in-app hash-based navigation hook to drive tab switching
- ensure the app renders without external routing scripts and keep the existing overview/graph/member views working

## Testing
- Manual verification in Playwright that the Family Tree Studio interface renders and tabs remain navigable

------
https://chatgpt.com/codex/tasks/task_e_68dd26cf8dbc8323be8291477638240a