### PR TITLE
Fix graph initialization when navigating between tabs

### DIFF
--- a/graph/useNetwork.jsx
+++ b/graph/useNetwork.jsx
@@ -34,7 +34,10 @@
     relationships,
     { onSelectMember, selectedMemberId } = {}
   ) {
-    const containerRef = React.useRef(null);
+    const [containerNode, setContainerNode] = React.useState(null);
+    const containerRef = React.useCallback((node) => {
+      setContainerNode(node);
+    }, []);
     const stateRef = React.useRef(null);
     const simulationRef = React.useRef(null);
     const selectCallbackRef = React.useRef(onSelectMember);
@@ -122,7 +125,6 @@
     }, []);
 
     React.useEffect(() => {
-      const containerNode = containerRef.current;
       if (!containerNode || !d3) {
         return undefined;
       }
@@ -244,7 +246,7 @@
           simulationRef.current = null;
         }
       };
-    }, [fitNetwork]);
+    }, [containerNode, fitNetwork]);
 
     React.useEffect(() => {
       const state = stateRef.current;


### PR DESCRIPTION
## Summary
- ensure the D3 network is reinitialized whenever the graph container mounts
- allow the graph view to render correctly after switching away and back without a manual refresh

## Testing
- Manual verification: opened the app, navigated between Overview and Graph tabs, and confirmed the graph renders without refreshing the page

------
https://chatgpt.com/codex/tasks/task_e_68dd2cf3b3e08323a13120cc0a3c07b7