### PR TITLE
Ensure graph renders when revisiting the graph tab

### DIFF
--- a/graph/useNetwork.jsx
+++ b/graph/useNetwork.jsx
@@ -481,7 +481,7 @@
         hideTooltip();
         simulation.on("tick", null);
       };
-    }, [members, relationships]);
+    }, [members, relationships, containerNode]);
 
     return { containerRef, fitNetwork, redrawNetwork };
   }


### PR DESCRIPTION
## Summary
- re-run the network graph rendering effect whenever the container mounts so nodes render after tab switches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd47782d888323bb9f610c75a76902