### PR TITLE
Adjust family tree node label position

### DIFF
--- a/graph/useNetwork.jsx
+++ b/graph/useNetwork.jsx
@@ -372,7 +372,7 @@
         .append("text")
         .attr("class", "node-label")
         .attr("text-anchor", "middle")
-        .attr("y", 48);
+        .attr("y", 56);
       nodeEnter.append("title");
 
       nodeEnter.call(dragBehavior);
@@ -380,7 +380,10 @@
 
       const mergedNodes = nodeEnter.merge(nodeSelection);
       mergedNodes.classed("is-deceased", (d) => d.isDeceased);
-      mergedNodes.select("text.node-label").text((d) => d.label);
+      mergedNodes
+        .select("text.node-label")
+        .attr("y", 56)
+        .text((d) => d.label);
       mergedNodes
         .select("image.node-image")
         .attr("href", (d) => d.image)


### PR DESCRIPTION
## Summary
- lower the node labels so they no longer overlap the avatar circles

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd70ec12f48323b28f948d8fb70c19