### PR TITLE
Add hierarchical tree view to family graph

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -394,11 +394,12 @@ function App() {
           expanded: graphExpanded,
           onToggle: handleToggleGraphExpanded,
         }}
-        network={{ containerRef }}
+        network={{ containerRef, fitNetwork, redrawNetwork }}
         memberDetail={{
           selectedMember,
           onClose: handleCloseMemberDetails,
         }}
+        onSelectMember={setSelectedMemberId}
         memberForm={memberForm}
         relationshipForm={relationshipForm}
         storageActions={{

--- a/styles.css
+++ b/styles.css
@@ -115,3 +115,145 @@ body {
   font-weight: 600;
   color: #1f2937;
 }
+
+.graph-hierarchy-scroll {
+  flex: 1;
+  position: relative;
+  overflow: auto;
+  padding: 24px 18px 32px;
+  background:
+    radial-gradient(circle at top, rgba(79, 70, 229, 0.05), transparent 60%),
+    linear-gradient(180deg, rgba(248, 250, 252, 0.82), #ffffff 68%);
+}
+
+.graph-hierarchy-root-list {
+  display: flex;
+  flex-direction: row;
+  gap: 48px;
+  align-items: flex-start;
+  justify-content: center;
+  min-width: 100%;
+  padding: 12px 16px 40px;
+  box-sizing: border-box;
+}
+
+.graph-hierarchy-tree {
+  --connector-color: rgba(79, 70, 229, 0.35);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: min(240px, 100%);
+}
+
+.graph-hierarchy-tree ul {
+  position: relative;
+  margin: 0;
+  padding: 28px 0 0;
+  list-style: none;
+  display: flex;
+  justify-content: center;
+}
+
+.graph-hierarchy-tree ul::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  border-left: 1px solid var(--connector-color);
+  height: 28px;
+}
+
+.graph-hierarchy-item {
+  position: relative;
+  list-style: none;
+  padding: 28px 20px 0;
+  text-align: center;
+}
+
+.graph-hierarchy-item::before,
+.graph-hierarchy-item::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  width: 50%;
+  height: 28px;
+  border-top: 1px solid var(--connector-color);
+}
+
+.graph-hierarchy-item::before {
+  left: 0;
+  border-left: 1px solid var(--connector-color);
+}
+
+.graph-hierarchy-item::after {
+  right: 0;
+  border-right: 1px solid var(--connector-color);
+}
+
+.graph-hierarchy-item:first-child::before,
+.graph-hierarchy-item:last-child::after {
+  border: none;
+}
+
+.graph-hierarchy-item:only-child::before,
+.graph-hierarchy-item:only-child::after {
+  border: none;
+}
+
+.graph-hierarchy-item:only-child {
+  padding-top: 0;
+}
+
+.graph-hierarchy-item.graph-hierarchy-root::before,
+.graph-hierarchy-item.graph-hierarchy-root::after {
+  border: none;
+}
+
+.graph-hierarchy-item.graph-hierarchy-root {
+  padding-top: 0;
+}
+
+.graph-hierarchy-tree ul:empty::before {
+  display: none;
+}
+
+.graph-hierarchy-node {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), #ffffff);
+  box-shadow: 0 14px 28px -24px rgba(15, 23, 42, 0.6);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.graph-hierarchy-node:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 38px -28px rgba(15, 23, 42, 0.65);
+}
+
+.graph-hierarchy-node.has-children {
+  border-color: rgba(79, 70, 229, 0.48);
+}
+
+.graph-hierarchy-node.is-selected {
+  border-color: #4f46e5;
+  box-shadow: 0 26px 46px -26px rgba(79, 70, 229, 0.55);
+}
+
+.graph-hierarchy-node:focus-visible {
+  outline: 2px solid #4f46e5;
+  outline-offset: 4px;
+}
+
+@media (max-width: 900px) {
+  .graph-hierarchy-root-list {
+    gap: 32px;
+    padding: 8px 12px 32px;
+  }
+
+  .graph-hierarchy-node {
+    border-radius: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a graph tab toggle that switches between the existing network and a new hierarchical tree layout
- render an interactive parent/child hierarchy that reuses member selection and detail panels
- refresh related styles and remove the old relationships-page hierarchy toggle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd7472e1ac8323ba7158074f275d0e