### PR TITLE
Enable panning and zooming in generational hierarchy

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -119,11 +119,28 @@ body {
 .graph-hierarchy-scroll {
   flex: 1;
   position: relative;
-  overflow: auto;
+  overflow: hidden;
   padding: 24px 18px 32px;
   background:
     radial-gradient(circle at top, rgba(79, 70, 229, 0.05), transparent 60%),
     linear-gradient(180deg, rgba(248, 250, 252, 0.82), #ffffff 68%);
+  touch-action: none;
+  cursor: grab;
+  user-select: none;
+}
+
+.graph-hierarchy-scroll.is-dragging {
+  cursor: grabbing;
+}
+
+.graph-hierarchy-canvas {
+  position: relative;
+  min-width: 100%;
+  min-height: 100%;
+  transform-origin: 0 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 .graph-hierarchy-root-list {
@@ -171,6 +188,7 @@ body {
   list-style: none;
   padding: 28px 20px 0;
   text-align: center;
+  flex: 0 0 auto;
 }
 
 .graph-hierarchy-item::before,
@@ -226,6 +244,7 @@ body {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), #ffffff);
   box-shadow: 0 14px 28px -24px rgba(15, 23, 42, 0.6);
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  user-select: text;
 }
 
 .graph-hierarchy-node:hover {


### PR DESCRIPTION
## Summary
- add refs and interaction handlers so the hierarchy canvas supports drag panning, wheel scrolling, and pinch zoom
- recenter the hierarchy when the view opens and provide a quick reset gesture
- refresh hierarchy styles to enable transform-based layout, prevent node overlap, and show grab cursors

## Testing
- Manual: Viewed the hierarchy tab in the browser and verified panning/zooming behaviour

------
https://chatgpt.com/codex/tasks/task_e_68dd8083bcfc8323a8c2ec8d21e38740